### PR TITLE
Feature/localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ typings/
 
 # Electron-Forge
 out/
+
+# Webstorm generated files
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "electron_typescript_vscode",
-  "version": "1.0.0",
+  "name": "AutoHotPie-Debug",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "electron_typescript_vscode",
-      "version": "1.0.0",
+      "name": "AutoHotPie-Debug",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/jquery": "^3.5.16",
@@ -15,7 +15,8 @@
         "bootstrap": "^5.2.3",
         "jquery": "^3.6.4",
         "konva": "^9.0.1",
-        "node-window-manager": "^2.2.4"
+        "node-window-manager": "^2.2.4",
+        "y18n": "^5.0.8"
       },
       "devDependencies": {
         "copyfiles": "^2.4.1",
@@ -1305,7 +1306,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }

--- a/src/index.html
+++ b/src/index.html
@@ -102,7 +102,7 @@
                                             <h4 class="text-nowrap text-truncate" id="application-profile-name-heading" style="margin-bottom: 0px;">{Pie Menu Name}</h4>
                                         </div>
                                         <div class="d-flex align-items-center main-run-btn" id="application-profile-save-and-run-btn" style="width: 190px;padding-left: 30px;color: var(--bs-body-color);"><i class="fa fa-play" id="sidebar-collapse-icon-left-5" style="font-size: 17px;"></i>
-                                            <h5 class="localization" ><localized-text key="save-and-run" /></h5>
+                                            <h5><localized-text key="save-and-run"></localized-text></h5>
                                         </div>
                                     </div>
                                     <div style="width: 100%;">
@@ -112,7 +112,7 @@
                                                     <tr>
                                                         <th style="width: 33.344px;"></th>
                                                         <th class="text-center" style="width: 90px;">Color</th>
-                                                        <th style="width: 203px;">Pie Key</th>
+                                                        <th style="width: 203px;"><localized-text key="pie-key"></localized-text></th>
                                                         <th>Name</th>
                                                         <th id="header-global-menu" style="width: 66px;">Global</th>
                                                         <th style="width: 34px;"></th>

--- a/src/index.html
+++ b/src/index.html
@@ -1,9 +1,8 @@
 <!DOCTYPE html>
-<html lang="en" style="height: 100%;">
 
 <head>
     <meta charset="utf-8">
-<script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
+    <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, shrink-to-fit=no">
     <title>AutoHotPieV2</title>
     <link rel="stylesheet" href="assets/bootstrap/css/bootstrap.min.css">
@@ -21,6 +20,7 @@
     <link rel="stylesheet" href="assets/css/styles.css">
     <link rel="stylesheet" href="assets/css/tables.css">
     <link rel="stylesheet" href="assets/css/topbar.css">
+    <script src="file:///build/lib/localization/localizedText.js"></script>
 </head>
 
 <body style="width: 100%;height: 100%;">
@@ -102,7 +102,7 @@
                                             <h4 class="text-nowrap text-truncate" id="application-profile-name-heading" style="margin-bottom: 0px;">{Pie Menu Name}</h4>
                                         </div>
                                         <div class="d-flex align-items-center main-run-btn" id="application-profile-save-and-run-btn" style="width: 190px;padding-left: 30px;color: var(--bs-body-color);"><i class="fa fa-play" id="sidebar-collapse-icon-left-5" style="font-size: 17px;"></i>
-                                            <h5>Save &amp; Run</h5>
+                                            <h5 class="localization" ><localized-text key="save-and-run" /></h5>
                                         </div>
                                     </div>
                                     <div style="width: 100%;">

--- a/src/lib/localization/localization.ts
+++ b/src/lib/localization/localization.ts
@@ -10,6 +10,8 @@ import {app} from "electron";
  *
  * You should call Localization.initialize() before using Localization.tr() if you wish to use a custom path
  * for the locale files.
+ *
+ * @example Localization.tr("hello");
  * */
 export class Localization {
     private static initialized = false;

--- a/src/lib/localization/localization.ts
+++ b/src/lib/localization/localization.ts
@@ -1,0 +1,60 @@
+import {app} from "electron";
+
+/**
+ * Text localization class.
+ * This class is used to localize text in electron's main process (i.e. outside the chromium renderer).
+ *
+ * Language is controlled using app.commandLine.appendSwitch(); which sets the language of the browser.
+ *
+ * Check https://www.electronjs.org/docs/latest/api/command-line-switches for more information.
+ *
+ * You should call Localization.initialize() before using Localization.tr() if you wish to use a custom path
+ * for the locale files.
+ * */
+export class Localization {
+    private static initialized = false;
+    private static translation = JSON.parse("{}");
+    private static fallBackTranslation = JSON.parse("{}");
+    private static path : string;
+
+    /**
+     * Initialize the localization class.
+     *
+     * This function may not be called if you wish to use the default path for the locale files.
+     *
+     * @param path The path to the locale files.
+     * */
+    public static initialize(path = "./src/locales/"): void {
+        if (Localization.initialized) {
+            return;
+        }
+
+        this.path = path;
+
+        const fs = require('fs');
+        let raw = fs.readFileSync(this.path + app.getLocale().split("-")[0] + '.json');
+        Localization.translation = JSON.parse(raw);
+
+        raw = fs.readFileSync(this.path + 'en.json');
+        Localization.fallBackTranslation = JSON.parse(raw);
+
+        Localization.initialized = true;
+    }
+
+    /**
+     * Get translation for a given key.
+     *
+     * @return The translated text if exists, default (fallback) language otherwise.
+     * */
+    public static tr(key: string): string {
+        if (!Localization.initialized) {
+            Localization.initialize();
+        }
+
+        if (!this.translation.hasOwnProperty(key)) {
+            return this.fallBackTranslation[key];
+        }
+
+        return this.translation[key];
+    }
+}

--- a/src/lib/localization/localization.ts
+++ b/src/lib/localization/localization.ts
@@ -11,6 +11,9 @@ import {app} from "electron";
  * You should call Localization.initialize() before using Localization.tr() if you wish to use a custom path
  * for the locale files.
  *
+ * @example Localization.initialize("./custom/path/to/locales/");
+ *          Localization.tr("hello");
+ *
  * @example Localization.tr("hello");
  * */
 export class Localization {

--- a/src/lib/localization/localizedText.js
+++ b/src/lib/localization/localizedText.js
@@ -5,10 +5,10 @@
  * Check https://www.electronjs.org/docs/latest/api/command-line-switches for more information.
  *
  * This class is not supposed to be used directly, instead include this file in <head>
- * in the HTML file and use the <local-txt> tag.
+ * in the HTML file and use the <localized-text> tag.
  *
- * <local-txt> provides 2 attributes, where lang is optional:
- * @example <local-txt txt="text to be translated" lang="en" /local-txt>
+ * <localized-text> provides 2 attributes, key and lang, where lang is optional:
+ * @example <localized-text key="text to be translated" lang="en" /localized-text>
  * */
 class LocalizedTextElement extends HTMLElement {
     constructor() {

--- a/src/lib/localization/localizedText.js
+++ b/src/lib/localization/localizedText.js
@@ -1,0 +1,46 @@
+/**
+ * Custom HTML element for text localization.
+ * Language is controlled using app.commandLine.appendSwitch(); which sets the language of the browser.
+ *
+ * Check https://www.electronjs.org/docs/latest/api/command-line-switches for more information.
+ *
+ * This class is not supposed to be used directly, instead include this file in <head>
+ * in the HTML file and use the <local-txt> tag.
+ *
+ * <local-txt> provides 2 attributes, where lang is optional:
+ * @example <local-txt txt="text to be translated" lang="en" /local-txt>
+ * */
+class LocalizedTextElement extends HTMLElement {
+    constructor() {
+        super();
+    }
+
+    connectedCallback() {
+        let key = this.hasAttribute('key') ? this.getAttribute('key') : '';
+        let lang = this.hasAttribute('lang') ? this.getAttribute('lang') : this.defaultLang();
+
+        console.log("Custom object local-t connected: {key: " + key + ", lang: " + lang + "}");
+
+        this.translate(key, lang).then((translated) => {
+            console.log("Translated: " + key + " -> " + translated);
+            this.innerText = translated;
+        });
+
+    }
+
+    defaultLang() {
+        let lang = (navigator.languages !== undefined) ? navigator.languages[0] : navigator.language;
+
+        // Ignore country code (example: en-US -> en)
+        return lang.split("-")[0];
+    }
+
+    async translate(key, lang) {
+        let translated = (await (await fetch("./locales/" + lang + ".json")).json())[key];
+        if (translated === undefined) translated = (await (await fetch("./locales/en.json")).json())[key];
+
+        return translated;
+    }
+}
+
+customElements.define('localized-text', LocalizedTextElement);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,4 @@
+{
+  "save-and-run": "Save & Run",
+  "import-setting": "Import Settings"
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,4 +1,14 @@
 {
   "save-and-run": "Save & Run",
-  "import-setting": "Import Settings"
+  "import-setting": "Import Settings",
+  "export-setting": "Export Settings",
+  "create-portable-ahk": "Create portable AHK package",
+  "settings": "Settings",
+  "save-and-run-long": "Save and Run",
+  "close-without-running": "Close without running",
+  "donate": "Donate",
+  "developer-tools": "Developer Tools",
+  "view-on-github": "View on GitHub",
+  "check-for-updates": "Check for updates",
+  "pie-key": "Pie Key"
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -1,0 +1,4 @@
+{
+  "save-and-run": "保存して実行",
+  "import-setting": "インポート"
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,13 +46,13 @@ function createWindow() {
             }    
           },
           {
-            label: 'Export Settings',          
+            label: Localization.tr("export-setting"),
             click: () => {
               mainWindow.webContents.send('menuSelected', 'exportSettings')            
             }          
           },        
           {
-            label: 'Create portable AHK package',          
+            label: Localization.tr("create-portable-ahk"),
             click: () => {
               mainWindow.webContents.send('menuSelected', 'createPortablePackage')
             }           
@@ -61,13 +61,13 @@ function createWindow() {
             type: 'separator'
           },
           { 
-            label: 'Save and Run',
+            label: Localization.tr("save-and-run-long"),
             click: () => {
               mainWindow.webContents.send('menuSelected', 'saveAndRun')
             }
           },
           { 
-            label: 'Close without running',          
+            label: Localization.tr("close-without-running"),
             click: () => {
               mainWindow.webContents.send('menuSelected', 'close')
             }
@@ -78,25 +78,25 @@ function createWindow() {
        role: 'help',
        submenu: [
           {
-             label: 'Check for Updates',
+             label: Localization.tr("check-for-updates"),
              click: () => {
               shell.openExternal('https://github.com/dumbeau/AutoHotPie/releases')             
              }
           },
           {
-            label: 'View on Github',
+            label: Localization.tr("view-on-github"),
             click: () => {
               shell.openExternal('https://github.com/dumbeau/AutoHotPie')             
             }
           },
           {
-            label: 'Donate',
+            label: Localization.tr("donate"),
             click: () => {
               shell.openExternal('https://www.paypal.com/donate?business=RBTDTCUBK4Z8S&no_recurring=1&item_name=Support+Pie+Menus+Development&currency_code=USD')             
             }
           },
           {
-            label: 'Developer Tools',
+            label: Localization.tr("developer-tools"),
             click: () => {
               mainWindow.webContents.openDevTools()              
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,14 @@ import { app, BrowserWindow, Menu, shell, ipcMain, nativeTheme, dialog, session,
 import * as path from "path";
 import * as fs from 'fs';
 import { windowManager } from "node-window-manager";
-
-
+import { Localization } from "./lib/localization/localization";
 
 let mainWindow: BrowserWindow;
+
+// TODO: Controls the language through settings
+// app.commandLine.appendSwitch('lang', 'ja-JP');
+
+
 function createWindow() {
 
   let windowWidth = (isDev()) ? 1500 : 800
@@ -35,7 +39,7 @@ function createWindow() {
        label: 'File',
        submenu: [
           {
-            label: 'Import Settings',          
+            label: Localization.tr('import-setting'),
             click: () => {  
               // ipcMain.send('menuSelected', event)
               mainWindow.webContents.send('menuSelected', 'importSettings')            
@@ -57,7 +61,7 @@ function createWindow() {
             type: 'separator'
           },
           { 
-            label: 'Save and Run',          
+            label: 'Save and Run',
             click: () => {
               mainWindow.webContents.send('menuSelected', 'saveAndRun')
             }
@@ -112,6 +116,8 @@ function createWindow() {
   
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu)
+
+
 }
 
 function isDev(){


### PR DESCRIPTION
I've created two class for localization, they're located in src/lib/localization/, one is used in the html files and one is for the main process, you could refer to the docstring in both files for details about the usage and description.

Usage in short:
For translations in html files, simply replace the text with `<localized-text key="key of the translation asset" />`.

> `<h5>Settings</h5>` -> `<h5><localized-text key="settings" /></h5>`

For the main process, replace the string in the code to `Localization.tr("key of the translation asset")`, notice that the `Localization` class should be imported.

> `label: 'Create portable AHK package',` -> `label: Localization.tr('create-portable-ahk'),`

The app language will be set by `app.commandLine.appendSwitch();` before the window is ready.
Locale files will be located at src/locales/
