### PR TITLE
add initial support to send a text string (#116)

### DIFF
--- a/src/lib/PieFunctions.ahk
+++ b/src/lib/PieFunctions.ahk
@@ -63,6 +63,17 @@ pie_sendKey(keyObject)
 	; msgbox, % keyObject.keys[4]	
 	
 
+pie_sendText(params)
+{
+	for index, txt in params.text
+	{
+		; msgbox pie_sendText`n%txt%
+		if (index = 1) ; just incase someone malforms the json
+			SendInput, {Text}%txt%
+	}
+}
+
+
 
 pie_mouseClick(params)
 	{


### PR DESCRIPTION
this is only implemented on the ahk side
at the moment, for the user to enable this, they must modify the json they should first add a sendKey action and save the menu and close then edit the json like so:
change 'sendKey' to 'sendText'
change 'params'->'keys' to 'params'->'text'

also used `Send, {Text}` as mentioned in issue #137

example of changes needed in the json:

![image](https://github.com/dumbeau/AutoHotPie/assets/1900684/fcd35895-b52b-4f0d-b9cb-d625e2c036ee)
