### PR TITLE
Add support for user-defined custom context sensitivity

### DIFF
--- a/src/PieMenu.ahk
+++ b/src/PieMenu.ahk
@@ -107,41 +107,18 @@ pieLabel: ;Fixed hotkey overlap "r and ^r", refactor this
 	PieLaunchedState := true
 	ActivePieHotkey := A_ThisHotkey
 
-	; msgbox, % ActivePieHotkey
-	; msgbox, % WinActive("ahk_exe explorer.exe")
-	If (!WinActive("ahk_group regApps"))
+
+	ActiveProfile := getActiveProfile()
+	activeProfileString := getProfileString(ActiveProfile)
+	if (activeProfileString = "ahk_group regApps")
 	{
-		profileIndex := 1
-		ActiveProfile := Settings.appProfiles[1]
 		Hotkey, IfWinNotActive, ahk_group regApps
 	}
-	else ;Registered applications
+	else
 	{
-		;Get application and key
-		; WinGet, activeWinProc, ProcessName, A
-		activeWinProc := getActiveProfileString()
-		;lookup profile and key index
-		for profileIndex, profile in Settings.appProfiles
-		{
-			if profileIndex == 1
-				continue
-			; if ahk_group regApps not contains activeWindow
-			for ahkHandleIndex, ahkHandle in profile.ahkHandles
-			{
-				testAHKHandle := StrSplit(ahkHandle, " ", ,2)[2] ;Will test multiple program, may be broken
-				; msgbox, % testAHKHandle . " " activeWinProc
-				if (testAHKHandle == activeWinProc) ;Is this the right profile?
-				{
-					; msgbox, what
-					ActiveProfile := profile
-					; Hotkey, IfWinActive, % "ahk_exe " + activeWinProc
-					Hotkey, IfWinActive, % activeWinProc
-					break 2
-				}
-			}
-		}
+		Hotkey, IfWinActive, % activeProfileString
 	}
-
+	
 	;Push hotkey to hotkeyArray to be blocked when pie menus are running.
 	for k, pieKey in ActiveProfile.pieKeys
 	{
@@ -169,7 +146,7 @@ pieLabel: ;Fixed hotkey overlap "r and ^r", refactor this
 		if (menu.hotkey == ActivePieHotkey)
 		{
 			blockBareKeys(ActivePieHotkey, hotKeyArray, true)
-			funcAddress := runPieMenu(profileIndex, k)
+			funcAddress := runPieMenu(ActiveProfile, k)
 			PieLaunchedState := false
 
 			if (ActiveProfile.pieEnableKey.useEnableKey)

--- a/src/PieMenu.ahk
+++ b/src/PieMenu.ahk
@@ -110,11 +110,17 @@ pieLabel: ;Fixed hotkey overlap "r and ^r", refactor this
 
 	ActiveProfile := getActiveProfile()
 	activeProfileString := getProfileString(ActiveProfile)
-	if (activeProfileString = "ahk_group regApps")
+	; tooltip % activeProfileString
+	if (SubStr(activeProfileString, -3) = "Func")       ;custom context
+	{
+		fn := Func(activeProfileString)
+		Hotkey, If, % fn
+	}
+	else if (activeProfileString = "ahk_group regApps")   ;default context
 	{
 		Hotkey, IfWinNotActive, ahk_group regApps
 	}
-	else
+	else                                                ;app specific context
 	{
 		Hotkey, IfWinActive, % activeProfileString
 	}

--- a/src/lib/BGFunks.ahk
+++ b/src/lib/BGFunks.ahk
@@ -453,9 +453,8 @@ getActiveMonitorDimensions()
 	}
 
 
-runPieMenu(profileNum, index, activePieNum=1)
+runPieMenu(p_activeProfile, index, activePieNum=1)
 	{
-	p_activeProfile := Settings.appProfiles[profileNum]
 	activePieKey := p_activeProfile.pieKeys[index]
 
 	PieOpenLocX := 0
@@ -1789,28 +1788,31 @@ getActiveProfile()
 			
 		}	
 	}
-getActiveProfileString()
+
+getProfileString(profile)
+{
+	; the json ahkHandles setting can be one of two things:
+	; 1. "ahk_group regApps" for the default pie menu (bad choice of setting value though because its really if that ahkgroup is NOT active)
+	; 2. array of exes for focused app context sensitivity (prefixed with "ahk_exe " due to appendAHKTag() )
+	;    if 2, then we need to loop through and figure out which of the exes is currently active
+	firstAhkHandle := profile.ahkHandles[1]
+	if (SubStr(firstAhkHandle, 1, 7) = "ahk_exe")
 	{
-	If (!WinActive("ahk_group regApps"))
-		{
-		return "ahk_group regApps"
-		}	
-	WinGet, activeWinProc, ProcessName, A
-	WinGetClass, activeWinClass, A
-	for profileIndex, profile in Settings.appProfiles ;Could refactor 
-		{
+		WinGet, activeWinProc, ProcessName, A
+		WinGetClass, activeWinClass, A
 		for ahkHandleIndex, ahkHandle in profile.ahkHandles
-			{
+		{
 			testAHKHandle := StrSplit(ahkHandle, " ", ,2)[2]
 			if (testAHKHandle == activeWinProc) || (testAHKHandle == activeWinClass)
 				{
 				; msgbox, profile.name
 				return testAHKHandle ; Could refactor and just pass the profile back as index 2
 				}				
-			}
-			
 		}	
 	}
+	else
+		return firstAhkHandle
+}
 
 hasValue(var, arr) {
 	arrOfKeys := []

--- a/src/lib/BGFunks.ahk
+++ b/src/lib/BGFunks.ahk
@@ -1828,7 +1828,7 @@ blockBareKeys(hotkeyInput, hotkeyArray, blockState=true){
 	; msgbox, % "input: " . hotkeyInput
 	; msgbox, % hotkeyArray[1]
 	; msgbox, % hotkeyArray[2]
-	if hotkeyArray[1] = ""
+	if (hotkeyArray[1] = "")
 		return
 	
 	for ahkHandleIndex, ahkHandle in ActiveProfile.ahkHandles
@@ -1836,7 +1836,7 @@ blockBareKeys(hotkeyInput, hotkeyArray, blockState=true){
 		if (ahkHandle == "ahk_group regApps"){
 			Hotkey, IfWinNotActive, ahk_group regApps
 		} else {
-			Hotkey, IfWinActive, % fullAHKHandle
+			Hotkey, IfWinActive, % ahkHandle
 		}
 		bareKey := removeCharacters(hotkeyInput, "+^!#")
 


### PR DESCRIPTION
# Why

Many users have requested the ability to have pie menus fire only when certain window _titles_ (not window exes) are active, or many other different requirements. This pull requests allows the user to write a custom AHK function for whatever requirement they have. If the function returns true, then the context sensitivity is applied. 

# Implementation

The `appProfiles[index].ahkHandles` setting inside the AHPSettings.json file contains the context that will be applied to that profile.  Currently, if that value is `ahk_group regApps` then that means the Default Profile is triggered and the menu will show whenever none of the other profile applications match. If that value is `appname.exe` then the menu will only be shown when that executable is active. 

We add a new option for the `appProfiles[index].ahkHandles` setting, and that is any string that ends in `Func` such as "myFunc". If that is found, then AutoHotPie will search for that function name, and use that function to determine the context sensitivity for that profile.

Since the function needs to be written in AHK and defined by the user, it requires the user to either
1. have the toggle turned on to "Use open source AHK to run the pie menus"
or
2. use the exported standalone ahk files

If two custom contexts both could match, the profile created first will take precedence. That is, the one higher up in the profile dropdown list

# Examples


For any user who wants to test the examples below, here are the necessary steps currently (if/when this PR code gets merged, these steps will change and probably best to check the main README):
1. Open AutoHotPie, click on the global Settings button in the upper left
2. Make sure the setting for "Use open source AutoHotkey pie menus" is turned ON
4. Create a new profile
5. Choose any focused application, it doesn't matter
6. Add a pie menu to this new profile
7. Save and run
8. Right click the AHK icon in the system tray near the clock, and click Exit
9. Open your AHP settings .json file. It is located in this location: `C:\Users\USERNAME\AppData\Roaming\AutoHotPie\AHPSettings.json`
10. CTRL+F to search for the new profile name you just created
11. On the next line, edit the `ahkHandles` section and change the app.exe to "MyContextFunc". Here's what the before and after should look like:
![image](https://github.com/dumbeau/AutoHotPie/assets/1900684/ea6cdfd2-1853-47be-9b18-79eb1e609990)
12. Save the file
13. Download this development branch here: https://github.com/mmikeww/AutoHotPie/archive/7d77326e9dc33c6ebe33e4291d80b958cc33e9d4.zip
14. Unzip, and open the folder `AutoHotPie\src\`
15. Right click the PieMenu.ahk file and choose 'Edit Script'
16. Scroll to the bottom of the file, and paste one of the functions below
17. Save the file and close it.
18. Double click that PieMenu.ahk and test



### Only show menu if a specific window title is active (Issue #95)
```ahk
MyContextFunc()
{
	; does window title contain "Untitled - Notepad" ?
	return WinActive("Untitled - Notepad")

	; or

	; is window title EXACTLY "Untitled - Notepad", and a notepad.exe window?
	; oldMatchMode := A_TitleMatchMode
	; SetTitleMatchMode, 3
	; result := WinActive("Untitled - Notepad ahk_exe notepad.exe")
	; SetTitleMatchMode, %oldMatchMode%
	; return result 
}
```

### Only show menu if the pixel at screen coordinate is a certain color (Issue #140)
```ahk
MyContextFunc()
{
	; is color at 1623x358 black ?
	PixelGetColor, color, 1623, 358
	if (color = 0x000000)
		return true
	return false
}
```

### Only show menu if mouse is within a certain screen area (Issue #53)
```ahk
MyContextFunc()
{
	; is mouse within the top left quadrant of the screen?
	MouseGetPos, mx, my
	if (mx >= 0) && (mx <= A_ScreenWidth/2) && (my >= 0) && (my <= A_ScreenHeight/2)
		return true
	return false
}
```

### Only show menu if certain apps are NOT active (Issue #85)
```ahk
MyContextFunc()
{
	if !WinActive("ahk_exe notepad.exe") && !WinActive("ahk_exe mspaint.exe")
		return true
	return false
}
```


Since the possibilities are endless, if users have other requirements, they can simply go to the AutoHotkey forums, and request help in building a function to meet their specific requirements.



